### PR TITLE
Fix warning in workflow: remove 'allowUpdates'

### DIFF
--- a/.github/workflows/build_paper.yml
+++ b/.github/workflows/build_paper.yml
@@ -49,7 +49,6 @@ jobs:
         release_name: Release ${{ github.ref }}-${{ github.run_number }}
         draft: false
         prerelease: false
-        allowUpdates: true
 
     - name: Upload Draft
       id: upload-release-draft


### PR DESCRIPTION
Warning: `Unexpected input(s) 'allowUpdates'`. I believe this parameter has been deprecated.