### PR TITLE
Add ignore rules for generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,9 @@
 *.fdb_latexmk
 *.out
 *.fls
+/*.pdf
+*.synctex.gz
+*.bbl
+*.blg
+*.zip
 tags


### PR DESCRIPTION
Adds ignore rules to ensure that paper.pdf and other generated files aren't commited by accident. 

Note that I couldn't execute make, as the build is currently broken on the master branch. 