### PR TITLE
fix: use minted's builtin Lean parser

### DIFF
--- a/paper.tex
+++ b/paper.tex
@@ -73,7 +73,7 @@
   % minted v3
   \newminted[mlir]{tools/lexers/MLIRLexer.py:MLIRLexerOnlyOps}{mathescape}
   \newminted[xdsl]{tools/lexers/MLIRLexer.py:MLIRLexer}{mathescape, style=murphy}
-  \newminted[lean4]{tools/lexers/Lean4Lexer.py:Lean4Lexer}{mathescape}
+  \newminted[lean4]{lean4}{mathescape}
 }
 {
   \ifcsdef{minted@optlistcl@quote}


### PR DESCRIPTION
Recent enough versions of minted ship a built-in parser/lexer for Lean code, which does much better than the python script we currently use at not drawing red boxes around symbols, so I propose we use the builtin one.

This matches what I've done in opencompl/paper-ssa-metatheory, and what @ineol and @bollu have told me they do in their Lean papers, so let's upstream that into the template